### PR TITLE
feat: Update lottery and fantasy page UX

### DIFF
--- a/public/pages/FantasyPage.tsx
+++ b/public/pages/FantasyPage.tsx
@@ -18,6 +18,7 @@ export const FantasyPage = () => {
         minutes: '00',
         seconds: '00'
     });
+    const [isTimeUp, setIsTimeUp] = useState(false);
 
     useEffect(() => {
         // Set the target date (July 18, 2025 at 9:00 PM EST)
@@ -35,6 +36,7 @@ export const FantasyPage = () => {
                     minutes: '00',
                     seconds: '00'
                 });
+                setIsTimeUp(true);
                 return;
             }
             
@@ -162,12 +164,17 @@ export const FantasyPage = () => {
                         <Button
                             variant="contained"
                             onClick={() => navigate('lottery')}
+                            disabled={!isTimeUp}
                             sx={{
                                 marginTop: '20px',
                                 backgroundColor: THEME.palette.sleeper.quaternary,
                                 color: THEME.palette.common.black,
                                 '&:hover': {
                                     backgroundColor: THEME.palette.sleeper.tertiary,
+                                },
+                                '&:disabled': {
+                                    backgroundColor: THEME.palette.button.tertiary,
+                                    color: THEME.palette.common.white,
                                 }
                              }}
                         >

--- a/public/pages/LotteryPage.tsx
+++ b/public/pages/LotteryPage.tsx
@@ -185,6 +185,9 @@ export const LotteryPage = () => {
 
   return (
     <PageContainer>
+      <ResetButtonContainer>
+        <ResetButton onClick={resetWheel}>Reset Draft</ResetButton>
+      </ResetButtonContainer>
       <Header>Welcome to the 2025 Fantasy Draft</Header>
       <DraftContainer>
   <FlexRow>
@@ -194,11 +197,11 @@ export const LotteryPage = () => {
         <SpinPointer />
       </WheelContainer>
       <Controls>
+      <div style={{ height: '60px' }} />
         <SpinButton onClick={spinWheel} disabled={isSpinning || remainingSpins <= 0}>
           {remainingSpins <= 0 ? 'Draft Complete!' : 'Spin Wheel'}
         </SpinButton>
         <RemainingSpins>Spins remaining: {remainingSpins}</RemainingSpins>
-        <ResetButton onClick={resetWheel}>Reset Draft</ResetButton>
       </Controls>
     </WheelWrapper>
 
@@ -265,6 +268,13 @@ const PageContainer = styled.div`
   text-align: center;
   padding: 2rem;
   min-height: 100vh;
+  position: relative;
+`;
+
+const ResetButtonContainer = styled.div`
+  position: absolute;
+  top: 1rem;
+  right: 1rem;
 `;
 
 const Header = styled.h1`


### PR DESCRIPTION
- Moved the reset draft button to the top right of the lottery page.
- Moved the spin wheel button further down on the lottery page.
- Disabled the 'Go to Lottery' button on the fantasy page until the timer is up.